### PR TITLE
fix mongo healthcheck command

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     volumes:
       - ./storage/mongo-1/:/data/db
     healthcheck:
-      test: test $$(mongosh --port ${MONGO_1_PORT} --quiet --eval "try {rs.initiate({_id:'${MONGO_REPLICA_SET}',members:[{_id:0,host:\"mongo-1:${MONGO_1_PORT}\"}]})} catch(e) {rs.status().ok}") -eq 1
+      test: test $$(mongosh --port ${MONGO_1_PORT} --quiet --eval "try {rs.status().ok || rs.initiate({_id:'${MONGO_REPLICA_SET}',members:[{_id:0,host:\"mongo-1:${MONGO_1_PORT}\"}]}).ok} catch(e) {rs.status().ok}" | grep -v asio.system) -eq 1
       interval: 10s
       start_period: 30s
 


### PR DESCRIPTION
On some systems (using mongo 6.0, but I guess 7.0 will have the same behaviour) current healthcheck command output looks like this:

```
dyumin@nas:/volume1/anytype/any-sync-dockercompose$ sudo docker-compose exec -it mongo-1 mongosh --port 27001 --quiet --eval "try {rs.initiate({_id:'rs0',members:[{_id:0,host:\"mongo-1:27001\"}]})} catch(e) {rs.status().ok}"
{"t":{"$date":"2024-05-05T18:44:44.379Z"},"s":"I",  "c":"NETWORK",  "id":5693100, "ctx":"js","msg":"Asio socket.set_option failed with std::system_error","attr":{"note":"connect (sync) TCP fast open","option":{"level":6,"name":30,"data":"01 00 00 00"},"error":{"what":"set_option: Protocol not available","message":"Protocol not available","category":"asio.system","value":92}}}
{ "ok" : 1 }
dyumin@nas:/volume1/anytype/any-sync-dockercompose$ sudo docker-compose exec -it mongo-1 mongosh --port 27001 --quiet --eval "try {rs.initiate({_id:'rs0',members:[{_id:0,host:\"mongo-1:27001\"}]})} catch(e) {rs.status().ok}"
{"t":{"$date":"2024-05-05T18:44:51.099Z"},"s":"I",  "c":"NETWORK",  "id":5693100, "ctx":"js","msg":"Asio socket.set_option failed with std::system_error","attr":{"note":"connect (sync) TCP fast open","option":{"level":6,"name":30,"data":"01 00 00 00"},"error":{"what":"set_option: Protocol not available","message":"Protocol not available","category":"asio.system","value":92}}}
{
	"ok" : 0,
	"errmsg" : "already initialized",
	"code" : 23,
	"codeName" : "AlreadyInitialized",
	"$clusterTime" : {
		"clusterTime" : Timestamp(1714934691, 1),
		"signature" : {
			"hash" : BinData(0,"AAAAAAAAAAAAAAAAAAAAAAAAAAA="),
			"keyId" : NumberLong(0)
		}
	},
	"operationTime" : Timestamp(1714934690, 3)
}
```

which leads to broken healthcheck

Proposed changes: 
1. filter out TCP fast open error (`grep -v asio.system`)
2. check `rs.status().ok` first and only then try to run `rs.initiate()`
3. use `.ok` field from `rs.initiate()` output json

<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
