### PR TITLE
fix: respect custom STORAGE_DIR in cleanEtcStorage and tighten volume…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,5 +49,8 @@ restart: down start
 update: pull down start
 upgrade: down clean start
 
+STORAGE_DIR := $(shell grep -m1 '^STORAGE_DIR=' .env 2>/dev/null | cut -d= -f2- | tr -d '"')
+STORAGE_DIR := $(if $(STORAGE_DIR),$(STORAGE_DIR),./storage)
+
 cleanEtcStorage:
-	rm -rf etc/ storage/
+	rm -rf etc/ $(STORAGE_DIR)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,8 @@ services:
       context: .
       dockerfile: Dockerfile-generateconfig-anyconf
     volumes:
-      - ./:/code:Z
+      - ./.env:/code/.env:ro,Z
+      - ./docker-generateconfig:/code/docker-generateconfig:ro,Z
       - "${STORAGE_DIR}:/code/storage:Z"
 
   # processing any-sync-* configs
@@ -19,7 +20,9 @@ services:
       context: .
       dockerfile: Dockerfile-generateconfig-processing
     volumes:
-      - ./:/code:Z
+      - ./.env:/code/.env:ro,Z
+      - ./docker-generateconfig:/code/docker-generateconfig:ro,Z
+      - ./etc:/code/etc:Z
       - "${STORAGE_DIR}:/code/storage:Z"
 
   mongo-1:


### PR DESCRIPTION
… mounts

- cleanEtcStorage now reads STORAGE_DIR from .env instead of hardcoding ./storage
- docker-compose: replace broad ./ bind-mount with explicit mounts (.env, docker-generateconfig, etc) to avoid exposing the whole repo into containers

<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
