### PR TITLE
chore: bump service versions to any-sync v0.12 releases

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,10 +7,10 @@
 # -----------------------------------------------------------------------------
 # Service versions
 # -----------------------------------------------------------------------------
-ANY_SYNC_NODE_VERSION=v0.11.1
-ANY_SYNC_FILENODE_VERSION=v0.11.1
-ANY_SYNC_COORDINATOR_VERSION=v0.9.1
-ANY_SYNC_CONSENSUSNODE_VERSION=v0.7.2
+ANY_SYNC_NODE_VERSION=v0.12.1
+ANY_SYNC_FILENODE_VERSION=v0.12.0
+ANY_SYNC_COORDINATOR_VERSION=v0.12.0
+ANY_SYNC_CONSENSUSNODE_VERSION=v0.12.0
 ANY_SYNC_TOOLS_VERSION=latest
 ANYTYPE_CLI_VERSION=latest
 


### PR DESCRIPTION
Updates `.env.example` to the latest **non-alpha** node releases, which are the ones built on any-sync v0.12.

| service | before | after |
|---|---|---|
| any-sync-node | v0.11.1 | **v0.12.1** |
| any-sync-filenode | v0.11.1 | **v0.12.0** |
| any-sync-coordinator | v0.9.1 | **v0.12.0** |
| any-sync-consensusnode | v0.7.2 | **v0.12.0** |

Versions come from the `prod` compatibility channel (puppetdoc.anytype.io), applied with `./update-versions.sh` — no hand-editing.

## Verification

Full stack started locally on these images:

- all containers up; mongo / redis / minio / netcheck healthchecks passing
- `netcheck` reports `success` against the coordinator
- no errors or panics in coordinator, node, filenode or consensusnode logs